### PR TITLE
Update cowitter version for HTTP/2 response problem

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.0.0",
-        "mpyw/cowitter": "1.0",
+        "mpyw/cowitter": "1.0.5",
         "vlucas/phpdotenv": "^3.4",
         "twig/twig": "^2.11",
         "twig/extensions": "^1.5",

--- a/composer.lock
+++ b/composer.lock
@@ -1,11 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "hash": "1ee81e2cfc3cd8eb34cd412a02afe09f",
-    "content-hash": "680614b747d346a9693d99ee3416815a",
+    "content-hash": "fb74c1fd79597bca125924e07e48b718",
     "packages": [
         {
             "name": "mpyw/co",
@@ -59,20 +58,20 @@
                 "http",
                 "parallel"
             ],
-            "time": "2016-08-28 14:02:56"
+            "time": "2016-08-28T14:02:56+00:00"
         },
         {
             "name": "mpyw/cowitter",
-            "version": "v1.0.0",
+            "version": "v1.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mpyw/cowitter.git",
-                "reference": "1668ef4c0411ab11a3fbc954f288c5c5e928aee2"
+                "reference": "f77bfa1cafe12927a987aa826b2fbf6433845c35"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mpyw/cowitter/zipball/1668ef4c0411ab11a3fbc954f288c5c5e928aee2",
-                "reference": "1668ef4c0411ab11a3fbc954f288c5c5e928aee2",
+                "url": "https://api.github.com/repos/mpyw/cowitter/zipball/f77bfa1cafe12927a987aa826b2fbf6433845c35",
+                "reference": "f77bfa1cafe12927a987aa826b2fbf6433845c35",
                 "shasum": ""
             },
             "require": {
@@ -81,12 +80,12 @@
                 "ext-openssl": "*",
                 "lib-curl": ">=7.20.0",
                 "mpyw/co": "^1.5",
-                "php": ">=5.5.0"
+                "php": ">=5.6.0"
             },
             "require-dev": {
-                "codeception/aspect-mock": "^2.0",
+                "codeception/aspect-mock": "^2.2",
                 "codeception/codeception": "^2.2",
-                "codeception/specify": "*",
+                "codeception/specify": "^0.4.6",
                 "mpyw/privator": "^2.0",
                 "php": ">=7.0.0",
                 "satooshi/php-coveralls": "^1.0"
@@ -120,7 +119,7 @@
                 "upload",
                 "video"
             ],
-            "time": "2016-08-27 13:11:56"
+            "time": "2019-05-16T13:42:58+00:00"
         },
         {
             "name": "phpfastcache/phpfastcache",
@@ -220,7 +219,7 @@
                 "zend memory cache",
                 "zend server"
             ],
-            "time": "2019-03-03 14:39:16"
+            "time": "2019-03-03T14:39:16+00:00"
         },
         {
             "name": "phpoption/phpoption",
@@ -270,7 +269,7 @@
                 "php",
                 "type"
             ],
-            "time": "2015-07-25 16:39:46"
+            "time": "2015-07-25T16:39:46+00:00"
         },
         {
             "name": "psr/cache",
@@ -316,7 +315,7 @@
                 "psr",
                 "psr-6"
             ],
-            "time": "2016-08-06 20:24:11"
+            "time": "2016-08-06T20:24:11+00:00"
         },
         {
             "name": "psr/simple-cache",
@@ -364,7 +363,7 @@
                 "psr-16",
                 "simple-cache"
             ],
-            "time": "2017-10-23 01:57:42"
+            "time": "2017-10-23T01:57:42+00:00"
         },
         {
             "name": "react/promise",
@@ -410,7 +409,7 @@
                 "promise",
                 "promises"
             ],
-            "time": "2019-01-07 21:25:54"
+            "time": "2019-01-07T21:25:54+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -468,7 +467,7 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2019-08-06 08:03:45"
+            "time": "2019-08-06T08:03:45+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -527,7 +526,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-08-06 08:03:45"
+            "time": "2019-08-06T08:03:45+00:00"
         },
         {
             "name": "twig/extensions",
@@ -582,7 +581,7 @@
                 "i18n",
                 "text"
             ],
-            "time": "2018-12-05 18:34:18"
+            "time": "2018-12-05T18:34:18+00:00"
         },
         {
             "name": "twig/twig",
@@ -649,7 +648,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2019-06-18 15:37:11"
+            "time": "2019-06-18T15:37:11+00:00"
         },
         {
             "name": "vlucas/phpdotenv",
@@ -706,7 +705,7 @@
                 "env",
                 "environment"
             ],
-            "time": "2019-08-27 17:00:38"
+            "time": "2019-08-27T17:00:38+00:00"
         }
     ],
     "packages-dev": [],

--- a/src/Twitter.php
+++ b/src/Twitter.php
@@ -65,12 +65,12 @@ class Twitter
     public function deleteTweet($id)
     {
         $errors = [];
-        $infomations = [];
+        $informations = [];
 
         if (!self::checkToken()) {
             return [
                 'errors' => $errors,
-                'infomations' => $infomations
+                'informations' => $informations
             ];
         }
 
@@ -78,7 +78,7 @@ class Twitter
             $status = $this->client->post('statuses/destroy', [
                 'id' => $id
             ]);
-            $infomations[] = [
+            $informations[] = [
                 'text' => '削除しました',
                 'url' => self::getTweetUrl($status),
             ];
@@ -93,7 +93,7 @@ class Twitter
 
         return [
             'errors' => $errors,
-            'infomations' => $infomations
+            'informations' => $informations
         ];
     }
 
@@ -101,7 +101,7 @@ class Twitter
     {
         $result = [
             'errors' => [],
-            'infomations'  => [],
+            'informations'  => [],
         ];
         $uploads = [];
 
@@ -165,13 +165,13 @@ class Twitter
     private function tweetText()
     {
         $errors = [];
-        $infomations = [];
+        $informations = [];
         try {
             $status = $this->client->post('statuses/update', [
                 'status' => $_POST["body"],
             ]);
         
-            $infomations[] = [
+            $informations[] = [
                 'text' => '投稿しました',
                 'url' => self::getTweetUrl($status),
             ];
@@ -181,17 +181,17 @@ class Twitter
 
         return [
             'errors' => $errors,
-            'infomations'  => $infomations
+            'informations'  => $informations
         ];
     }
 
     private function tweetMedia($files, $isVideo = false)
     {
         $errors = [];
-        $infomations  = [];
+        $informations  = [];
 
         try {
-            $infomations = Co::wait(function () use ($infomations, $files, $isVideo) {
+            $informations = Co::wait(function () use ($informations, $files, $isVideo) {
                 $status = [];
                 $media_ids = [];
                 // 通常の画像
@@ -218,12 +218,12 @@ class Twitter
                     'status' => $_POST["body"] ?? '',
                     'media_ids' => $media_ids,
                 ]);
-                $infomations[] = [
+                $informations[] = [
                     'text' => '投稿しました',
                     'url' => self::getTweetUrl($status),
                 ];
 
-                return $infomations;
+                return $informations;
             });
         } catch (\RuntimeException $e) {
             $errors[] = $e->getMessage();
@@ -231,7 +231,7 @@ class Twitter
 
         return [
             'errors'      => $errors,
-            'infomations' => $infomations
+            'informations' => $informations
         ];
     }
 

--- a/src/view/template/index.tpl.html
+++ b/src/view/template/index.tpl.html
@@ -11,8 +11,8 @@
     {% endfor %}
 {% endif %}
 
-{% if infomations|length > 0 %}
-    {% for info in infomations %}
+{% if informations|length > 0 %}
+    {% for info in informations %}
         <div class="notification is-info">
             <button class="delete"></button>
             {{ info.text }}: <a href="{{ info.url }}" target="_blank">{{ info.url }}</a>


### PR DESCRIPTION
https://github.com/mpyw/cowitter/pull/20

In some environment, 'Invalid response line' will be happened with mpyw/cowitter:1.0.0.
We should use mpyw/cowitter:1.0.5 for this reason.